### PR TITLE
es.dat support

### DIFF
--- a/source/ini.c
+++ b/source/ini.c
@@ -121,6 +121,9 @@ void saveSettings()
 		if (getLanguage() == 1) {
 			fprintf(f, "en");
 		}
+		if (getLanguage() == 2) {
+			fprintf(f, "es");
+		}
 		
 		//Autosave
 		fprintf(f, "\r\nautosave=");
@@ -300,6 +303,9 @@ void languageLoad(char* first, char* second)
 		}
 		if (strcmp(second, "jp") == 0) {
 			setLanguage(JAPANESE);
+		}
+		if (strcmp(second, "es") == 0) {
+			setLanguage(SPANISH);
 		}
 	}
 }

--- a/source/options.c
+++ b/source/options.c
@@ -102,6 +102,8 @@ int optionsStep()
 			if (optCursor == 0) {
 				if (getLanguage() == JAPANESE) {
 					setLanguage(ENGLISH);
+				} else if (getLanguage() == ENGLISH) {
+					setLanguage(SPANISH);
 				}else{
 					setLanguage(JAPANESE);
 				}
@@ -190,12 +192,24 @@ void optionsDraw()
 		
 		//Language
 		PHL_DrawTextBold("LANGUAGE", xleft, ydraw, YELLOW);
-		if (getLanguage() == 1) {
-			PHL_DrawTextBold("EN", xright, ydraw, YELLOW);
+		switch (getLanguage()) {
+			case JAPANESE:
+				PHL_DrawTextBold("JP", xright, ydraw, YELLOW);
+				break;
+			default:
+			case ENGLISH:
+				PHL_DrawTextBold("EN", xright, ydraw, YELLOW);
+				break;
+			case SPANISH:
+				PHL_DrawTextBold("ES", xright, ydraw, YELLOW);
+				break;
 		}
-		if (getLanguage() == 0) {
-			PHL_DrawTextBold("JP", xright, ydraw, YELLOW);
-		}
+		//if (getLanguage() == 1) {
+		//	PHL_DrawTextBold("EN", xright, ydraw, YELLOW);
+		//}
+		//if (getLanguage() == 0) {
+		//	PHL_DrawTextBold("JP", xright, ydraw, YELLOW);
+		//}
 		
 		ydraw += ystep;
 		optioncount++;

--- a/source/text.c
+++ b/source/text.c
@@ -73,7 +73,7 @@ void loadText()
 		strcpy(fullPath, "romfs:/");
 	#else
 		#ifdef _PSP2
-			sprintf(fullPath, "%s:data/HCL/%s", use_uma0 ? "uma0" : "ux0", (gameLanguage == ENGLISH) ? "en.dat" : "jp.dat");
+			sprintf(fullPath, "%s:data/HCL/%s", use_uma0 ? "uma0" : "ux0", (gameLanguage == ENGLISH) ? "en.dat" : ((gameLanguage==SPANISH)?"es.dat":"jp.dat"));
 		#else
 			strcpy(fullPath, "romfs/");
 		#endif
@@ -83,7 +83,9 @@ void loadText()
 	#ifndef _PSP2
 	if (gameLanguage == ENGLISH) {
 		strcat(fullPath, "en.dat");
-	}else{
+	} else if (gameLanguage == SPANISH) {
+		strcat(fullPath, "es.dat");
+	} else{
 		strcat(fullPath, "jp.dat");
 	}
 	#endif

--- a/source/text.h
+++ b/source/text.h
@@ -3,6 +3,7 @@
 
 #define JAPANESE 0
 #define ENGLISH 1
+#define SPANISH 2
 
 char gameLanguage;
 


### PR DESCRIPTION
This commit adds in-game support for the Spanish translation of HCL, as long as the game data folder contains the files Es.dat and bmp.qda from this thread, also attached here
[es2.zip](https://github.com/Rinnegatamante/HCL-Vita/files/1524016/es2.zip)
:
https://github.com/Rinnegatamante/HCL-Vita/issues/8

This commit does not translate hard-coded text in the source code (menus, ending credits, etc.). Refactoring for better translation support (in the form of external text files) would be desirable.